### PR TITLE
Add support for Bitbucket pipelines

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,27 @@
+image: curlimages/curl:latest
+
+pipelines:
+  tags:
+    '*':
+      - step:
+          name: Pre-check for Environment Variables
+          script:
+            - echo "Checking if necessary environment variables are defined..."
+            - |
+              if [ -z "$PACKAGIST_USERNAME" ]; then
+                echo "Error: PACKAGIST_USERNAME is not defined"
+                exit 1
+              fi
+              if [ -z "$PACKAGIST_TOKEN" ]; then
+                echo "Error: PACKAGIST_TOKEN is not defined"
+                exit 1
+              fi
+      - step:
+          name: Update Packagist
+          script:
+            - |
+              curl -XPOST -H 'content-type:application/json' \
+              "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+              -d "{\"repository\":{\"url\":\"https://bitbucket.org/${BITBUCKET_REPO_FULL_NAME}\"}}"
+          needs:
+            - step: Pre-check for Environment Variables


### PR DESCRIPTION
Added support for running the CI/CD pipelines on Bitbucket.

This pipeline runs on each pull-request and each time the main branch gets new changes.

Required vars:
- PACKAGIST_USERNAME
- PACKAGIST_TOKEN